### PR TITLE
fixed extraneous } in Docker/SynthEx.R

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -14,7 +14,7 @@ RUN Rscript -e 'install.packages (c("mclust","flsa","foreach","ggplot2","gridExt
 
 
 ADD https://github.com/arq5x/bedtools2/releases/download/v2.26.0/bedtools-2.26.0.tar.gz bedtools-2.26.0.tar.gz
-RUN tar -zxf bedtools-2.26.0.tar.gz && cd bedtools2 && make && make install
+RUN tar zxf bedtools-2.26.0.tar.gz && cd bedtools2 && make && make install
 
 
 # Clean up APT when done.

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -14,13 +14,14 @@ RUN Rscript -e 'install.packages (c("mclust","flsa","foreach","ggplot2","gridExt
 
 
 ADD https://github.com/arq5x/bedtools2/releases/download/v2.26.0/bedtools-2.26.0.tar.gz bedtools-2.26.0.tar.gz
-RUN tar zxf bedtools-2.26.0.tar.gz && cd bedtools2 && make && make install
+RUN tar --no-same-owner -zxf bedtools-2.26.0.tar.gz && cd bedtools2 && make && make install
 
 
 # Clean up APT when done.
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* bedtools*
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /bedtools*
+
+COPY Rprofile.site /etc/R/
+COPY SynthEx.R /SynthEx.R
 
 ENTRYPOINT ["Rscript", "/SynthEx.R"]
 CMD ["--help"]
-ADD Rprofile.site /etc/R
-ADD SynthEx.R /SynthEx.R

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -14,7 +14,7 @@ RUN Rscript -e 'install.packages (c("mclust","flsa","foreach","ggplot2","gridExt
 
 
 ADD https://github.com/arq5x/bedtools2/releases/download/v2.26.0/bedtools-2.26.0.tar.gz bedtools-2.26.0.tar.gz
-RUN tar --no-same-owner -zxf bedtools-2.26.0.tar.gz && cd bedtools2 && make && make install
+RUN tar -zxf bedtools-2.26.0.tar.gz && cd bedtools2 && make && make install
 
 
 # Clean up APT when done.

--- a/Docker/SynthEx.R
+++ b/Docker/SynthEx.R
@@ -27,6 +27,10 @@ option_list <- list (
                                   default="/tmp",
                                   help="the temporary directory [default %default]"),
                      
+                     make_option (c("-k","--numnormals"),
+                                  default="4",
+                                  help="the number of normals to use for normalization [default %default]"),
+                     
                      make_option (c("-b","--bin"),
                                   default=50000,
                                   help="The bin size for the genome windows[default %default]"),
@@ -59,6 +63,8 @@ normal.file <- opt$normal
 tumor.file <- opt$tumor
 sample.name <- opt$samplename
 genotype.file <- opt$genotype
+numnormals <- opt$numnormals
+
 debug <- opt$debug
 if (debug) {
     cat (paste("bin.size:", bin.size,"\n","tumor.file:",tumor.file,"\nnormal.file:",normal.file,"\ngenotype.file: ",genotype.file,"\n"))
@@ -71,7 +77,14 @@ centromereBins <- createCentromereBins(bin.size=bin.size)
 
 
 cat ("------Running SynthExPipeline------\n")
-Segfrompipe <- SynthExPipeline (tumor.file,normal.file,bin.size=bin.size,intersectBed.dir,genotype.file=genotype.file, result.dir,working.dir,prefix=sample.name,verbose=debug)
+Segfrompipe <- SynthExPipeline (tumor.file,normal.file,
+                                bin.size=bin.size,
+                                intersectBed.dir,
+                                genotype.file=genotype.file, 
+                                result.dir,working.dir,
+                                prefix=sample.name,
+                                verbose=debug,
+                                K=numnormals)
 
 cat ("------Finished running SynthExPipeline------\n")
 

--- a/Docker/SynthEx.R
+++ b/Docker/SynthEx.R
@@ -70,8 +70,8 @@ if (debug) {cat ("Generating centromere Bins\n")}
 centromereBins <- createCentromereBins(bin.size=bin.size)
 
 
-cat ("------Running SynthExPipeline------\n")}
+cat ("------Running SynthExPipeline------\n")
 Segfrompipe <- SynthExPipeline (tumor.file,normal.file,bin.size=bin.size,intersectBed.dir,genotype.file=genotype.file, result.dir,working.dir,prefix=sample.name,verbose=debug)
 
-cat ("------Finished running SynthExPipeline------\n")}
+cat ("------Finished running SynthExPipeline------\n")
 

--- a/R/SynthExPipeline.R
+++ b/R/SynthExPipeline.R
@@ -4,7 +4,7 @@ SynthExPipeline <- function(tumor, normal, bin.size, bedTools.dir, genotype.file
                             rm.centromere = TRUE, targetAnnotateBins = NULL, centromereBins = NULL, chrX = FALSE,
                             report = TRUE, plot = TRUE, prefix = NULL, reads.threshold = 25, vcf = TRUE,
                             adjust.cutoff = 1.2, seg.count = 200, segmentMethod = "CBS",
-                            smoothk = 10, ratio.cutoff = 0.05,
+                            smoothk = 10, ratio.cutoff = 0.05, K = 1,
                             WGD = 1.35, pos.prop.threhold = 0.6, pos.log2ratio.threhold = 0.75,
                             prop.threshold = 0.0005, delta = 0.1, maf.control = 0.01,
                             tau = 2, sigma = 0.1, len.threshold.K = 10,  group.length.threshold = 2,
@@ -12,7 +12,7 @@ SynthExPipeline <- function(tumor, normal, bin.size, bedTools.dir, genotype.file
 
   ratioCorrectedBias <- SynthExcorrectBias(tumor, normal, bin.size = bin.size, rm.centromere = rm.centromere,
              targetAnnotateBins = targetAnnotateBins, saveplot = saveplot, centromereBins = centromereBins,
-             chrX = chrX, plot = plot, result.dir = result.dir, working.dir = working.dir,
+             chrX = chrX, plot = plot, result.dir = result.dir, working.dir = working.dir, K =K, 
              prefix = prefix, reads.threshold = reads.threshold)
 
   if(verbose == TRUE) print("Bias correction finished.")


### PR DESCRIPTION
When I added some command line reporting, I accidentally left a couple of } at the ends of the cat lines.  