### PR TITLE
setup travis CI and revise installation guide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: r
+os: [linux, osx]
+r: [release, devel, oldrel]
+matrix:
+  fast_finish: true
+  allow_failures:
+  - r: devel
+  - r: oldrel
+cache: packages
+latex: false
+pandoc: false
+fortran: true
+git:
+  depth: false
+
+before_install:
+  - R -e "if (Sys.getenv('TRAVIS_EVENT_TYPE') == 'cron') unlink(dir(.libPaths()[1], full.names = T), recursive = T)"
+install:
+  - R --slave -e "if (!('devtools' %in% .packages(T))) install.packages('devtools')"
+  - R --slave -e "devtools::install_github('r-lib/devtools')"
+  - R --slave -e "source('https://bioconductor.org/biocLite.R')"
+script:
+  - R --slave -e "devtools::install_local(getwd())"
+  - R --slave -e "devtools::update_packages('testthat'); if (dir.exists('tests/testthat')) devtools::test()"
+
+notifications:
+  email: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,5 +7,7 @@ Author: Mengjie Chen
 Maintainer: Mengjie Chen <mengjiechen@uchicago.edu>
 Description: SynthEx is a comprehensive suite of tools for CNA detection and tumor heterogeneity profiling.
 License: GPL (>=2)
+SystemRequirements: gfortran (for mclust)
 LinkingTo: mclust, flsa, foreach, DNAcopy, ggplot2, gridExtra, inline, Rcpp
-Imports: mclust, flsa, foreach, DNAcopy, ggplot2, gridExtra, inline, Rcpp
+Imports: mclust, flsa, foreach, ggplot2, gridExtra, inline, Rcpp
+Remotes: bioc::release/DNAcopy

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ### SynthEx
 
+[![Build Status](https://travis-ci.org/dongzhuoer/SynthEx.svg?branch=master)](https://travis-ci.org/dongzhuoer/SynthEx)
+
 **SynthEx** is a comprehensive suite of tools for CNA detection and tumor heterogeneity profiling. 
 It is tailored to cater for the multiple characteristics of different next generation sequencing technologies. 
 
@@ -11,28 +13,18 @@ It is tailored to cater for the multiple characteristics of different next gener
 
 ### Installation
 
-**SynthEx** relies on the following R packages: **mclust**, **flsa**, **foreach**, **DNAcopy**, **ggplot2**, **gridExtra**, **inline**, and **Rcpp**. Among these, **DNAcopy** is hosted on BioConductor and all the others are hosted on CRAN. 
-  ```R
-  install.packages ("mclust")
-  install.packages ("flsa")
-  install.packages ("foreach")
-  install.packages ("ggplot2")
-  install.packages ("gridExtra")
-  install.packages ("inline")
-  install.packages ("Rcpp")
-  source("https://bioconductor.org/biocLite.R")
-  biocLite()
-  biocLite("DNAcopy")
-  ```
-
 **SynthEx** can be installed from github directly as follows:
 
-  ```R
-  install.packages ("devtools")
-  library(devtools)
-  install_github("ChenMengjie/SynthEx")
-  ```
-  
+```r
+source('https://bioconductor.org/biocLite.R')
+source('https://install-github.me/r-lib/devtools')
+
+devtools::install_github("ChenMengjie/SynthEx")
+```
+
+**SynthEx** relies on the following R packages: **mclust**, **flsa**, **foreach**, **DNAcopy**, **ggplot2**, **gridExtra**, **inline**, and **Rcpp**. Among these, **DNAcopy** is hosted on BioConductor and all the others are hosted on CRAN. 
+They are installed automatically by the above command. 
+
 ### Tutorial
 
 A tutorial with examples illustrating the usage of **SynthEx** is distributed together with the package, also available at: https://github.com/ChenMengjie/SynthEx/blob/master/inst/doc/SynthExUserGuide.pdf. 


### PR DESCRIPTION
Continuous integration can help you detect bugs early and keep you confident when release a new version.